### PR TITLE
Replaced NULL with '' (emty string) in Security and Utils command

### DIFF
--- a/src/Command/Security/SecurityPasswordCommand.php
+++ b/src/Command/Security/SecurityPasswordCommand.php
@@ -24,7 +24,7 @@ class SecurityPasswordCommand extends AbstractCommand
 		$this->setName('nette:security:password');
 		$this->setDescription('Generates password (s) using Nette Passwords');
 		$this->addArgument('password', InputArgument::OPTIONAL, 'Given password');
-		$this->addOption('count', 'c', InputOption::VALUE_OPTIONAL, NULL, 10);
+		$this->addOption('count', 'c', InputOption::VALUE_OPTIONAL, '', 10);
 	}
 
 	/**

--- a/src/Command/Utils/UtilsRandomCommand.php
+++ b/src/Command/Utils/UtilsRandomCommand.php
@@ -21,7 +21,7 @@ class UtilsRandomCommand extends AbstractCommand
 	{
 		$this->setName('nette:utils:random');
 		$this->setDescription('Generates random string(s) using Nette Random');
-		$this->addOption('count', 'c', InputOption::VALUE_OPTIONAL, NULL, 10);
+		$this->addOption('count', 'c', InputOption::VALUE_OPTIONAL, '', 10);
 	}
 
 	/**


### PR DESCRIPTION
It has to be replaced, sice with typhints only `string` can be passed, not `NULL` as used before.

This PR has fixed `CRITICAL: TypeError`, full error report can be found here: https://gist.github.com/vojtamares/095e6d080b923f4b755138c9c391e1f4

It is a tiny change and should not break a thing