### PR TITLE
Docs: fix typo in the configuration of Cache console

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -80,7 +80,7 @@ At this moment, these bridges are available:
 ### CacheConsole
 
 ```yaml
-cache.console:
+console.cache:
     purge:
         - %tempDir%/cache
 ```


### PR DESCRIPTION
Signed-off-by: Roman Ondráček <ondracek.roman@centrum.cz>