### PR TITLE
ConsoleBridgesExtension: Fix default config for compiler passes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
     "phpstan/phpstan-shim": "^0.11",
     "phpstan/phpstan-strict-rules": "^0.11"
   },
+  "conflict": {
+    "nette/schema": "<1.0.1"
+  },
   "suggest": {
     "contributte/console": "Symfony\\Console for Nette"
   },

--- a/src/DI/AdvancedCacheConsoleExtension.php
+++ b/src/DI/AdvancedCacheConsoleExtension.php
@@ -44,7 +44,7 @@ class AdvancedCacheConsoleExtension extends CompilerExtension
 		// Register generators
 		$generatorDefinitions = [];
 
-		foreach (($config->generators ?? []) as $generatorName => $generatorConfig) {
+		foreach ($config->generators as $generatorName => $generatorConfig) {
 			$generatorPrefix = $this->prefix('generator.' . $generatorName);
 			$generatorDefinition = $definitionsHelper->getDefinitionFromConfig($generatorConfig, $generatorPrefix);
 
@@ -62,7 +62,7 @@ class AdvancedCacheConsoleExtension extends CompilerExtension
 		// Register cleaners
 		$cleanerDefinitions = [];
 
-		foreach (($config->cleaners ?? []) as $cleanerName => $cleanerConfig) {
+		foreach ($config->cleaners as $cleanerName => $cleanerConfig) {
 			$cleanerPrefix = $this->prefix('cleaner.' . $cleanerName);
 			$cleanerDefinition = $definitionsHelper->getDefinitionFromConfig($cleanerConfig, $cleanerPrefix);
 

--- a/src/DI/CacheConsoleExtension.php
+++ b/src/DI/CacheConsoleExtension.php
@@ -33,7 +33,7 @@ final class CacheConsoleExtension extends CompilerExtension
 		$config = $this->config;
 
 		// Default values cannot be in schema, arrays are merged by keys
-		if (!isset($config->purge) || ($config->purge === [])) {
+		if ($config->purge === []) {
 			$config->purge = Helpers::expand(['%tempDir%/cache'], $builder->parameters);
 		}
 

--- a/src/DI/ConsoleBridgesExtension.php
+++ b/src/DI/ConsoleBridgesExtension.php
@@ -6,7 +6,6 @@ use Nette\DI\CompilerExtension;
 use Nette\PhpGenerator\ClassType;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
-use stdClass;
 
 /**
  * @property-read mixed[] $config
@@ -16,15 +15,20 @@ final class ConsoleBridgesExtension extends CompilerExtension
 
 	public function getConfigSchema(): Schema
 	{
+		$advancedCache = AdvancedCacheConsoleExtension::createSchema();
+		$cache = CacheConsoleExtension::createSchema();
+		$di = DIConsoleExtension::createSchema();
+		$latte = LatteConsoleExtension::createSchema();
+
 		return Expect::structure([
-			'advancedCache' => Expect::anyOf(false, AdvancedCacheConsoleExtension::createSchema())->default(new stdClass()),
-			'cache' => Expect::anyOf(false, CacheConsoleExtension::createSchema())->default(new stdClass()),
-			'caching' => Expect::anyOf(false)->default(new stdClass()),
-			'di' => Expect::anyOf(false, DIConsoleExtension::createSchema())->default(new stdClass()),
-			'latte' => Expect::anyOf(false, LatteConsoleExtension::createSchema())->default(new stdClass()),
-			'router' => Expect::anyOf(false)->default(new stdClass()),
-			'security' => Expect::anyOf(false)->default(new stdClass()),
-			'utils' => Expect::anyOf(false)->default(new stdClass()),
+			'advancedCache' => Expect::anyOf(false, $advancedCache)->default($advancedCache),
+			'cache' => Expect::anyOf(false, $cache)->default($cache),
+			'caching' => Expect::anyOf(false),
+			'di' => Expect::anyOf(false, $di)->default($di),
+			'latte' => Expect::anyOf(false, $latte)->default($latte),
+			'router' => Expect::anyOf(false),
+			'security' => Expect::anyOf(false),
+			'utils' => Expect::anyOf(false),
 		])->castTo('array');
 	}
 

--- a/src/DI/DIConsoleExtension.php
+++ b/src/DI/DIConsoleExtension.php
@@ -33,7 +33,7 @@ final class DIConsoleExtension extends CompilerExtension
 		$config = $this->config;
 
 		// Default values cannot be in schema, arrays are merged by keys
-		if (!isset($config->purge) || ($config->purge === [])) {
+		if ($config->purge === []) {
 			$config->purge = Helpers::expand(['%tempDir%/cache/nette.configurator'], $builder->parameters);
 		}
 

--- a/src/DI/LatteConsoleExtension.php
+++ b/src/DI/LatteConsoleExtension.php
@@ -36,18 +36,18 @@ final class LatteConsoleExtension extends CompilerExtension
 		$config = $this->config;
 
 		// Default values cannot be in schema, arrays are merged by keys
-		if (!isset($config->warmup) || ($config->warmup === [])) {
+		if ($config->warmup === []) {
 			$config->warmup = Helpers::expand(['%appDir%'], $builder->parameters);
 		}
 
-		if (!isset($config->purge) || ($config->purge === [])) {
+		if ($config->purge === []) {
 			$config->purge = Helpers::expand(['%tempDir%/cache/latte'], $builder->parameters);
 		}
 
 		$builder->addDefinition($this->prefix('warmup'))
 			->setFactory(LatteWarmupCommand::class, [
 				1 => $config->warmup,
-				2 => $config->warmupExclude ?? [],
+				2 => $config->warmupExclude,
 			]);
 
 		$builder->addDefinition($this->prefix('purge'))


### PR DESCRIPTION
Partially reverts #23 and sets correct default config