### PR TITLE
README.md - configurator service definition

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -245,7 +245,7 @@ console.advancedCache:
    ```yaml
    services:
        configurator:
-           class: Nette\Configurator
+           type: Nette\Configurator
            imported: true
    ```
 

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -245,7 +245,7 @@ console.advancedCache:
    ```yaml
    services:
        configurator:
-           factory: Nette\Configurator
+           class: Nette\Configurator
            imported: true
    ```
 


### PR DESCRIPTION
This code:

```yaml
services:
    configurator:
        class: Nette\Configurator
        imported: true
```
throws this exception:

```
Nette\DI\InvalidConfigurationException

Unexpected option 'services › configurator › factory'.
```

Switching `factory` (which in case of Configurator doesn't make sense, I guess) to `class` fixes the error. 
However, at this point I'm not sure whether it actually works, because I get a different & unrelated error(s) - I'm in the process of updating my app to Nette 3 :)