### PR TITLE
Show child class name in error message instead of AbstractCompilerExtension

### DIFF
--- a/src/DI/AbstractCompilerExtension.php
+++ b/src/DI/AbstractCompilerExtension.php
@@ -18,7 +18,7 @@ abstract class AbstractCompilerExtension extends CompilerExtension
 	public function __construct(bool $cliMode = false)
 	{
 		if (func_num_args() <= 0) {
-			throw new InvalidArgumentException(sprintf('Provide CLI mode, e.q. %s(%%consoleMode%%).', self::class));
+			throw new InvalidArgumentException(sprintf('Provide CLI mode, e.q. %s(%%consoleMode%%).', static::class));
 		}
 
 		$this->cliMode = $cliMode;


### PR DESCRIPTION
Show child class name in error message instead of AbstractCompilerExtension.

![Screenshot from 2022-02-22 12-36-58](https://user-images.githubusercontent.com/2609142/155124801-daa73522-d7fe-4af1-9567-bc5945742c72.png)

