### PR TITLE
Fix PHPStan list type for Latte Finder paths

### DIFF
--- a/src/Cache/Generators/LatteTemplatesCacheGenerator.php
+++ b/src/Cache/Generators/LatteTemplatesCacheGenerator.php
@@ -13,8 +13,8 @@ class LatteTemplatesCacheGenerator implements IGenerator
 {
 
 	/**
-	 * @param string[] $dirs
-	 * @param string[] $excludeDirs
+	 * @param list<string> $dirs
+	 * @param list<string> $excludeDirs
 	 */
 	public function __construct(
 		private readonly TemplateFactory $templateFactory,

--- a/src/Command/Latte/LatteWarmupCommand.php
+++ b/src/Command/Latte/LatteWarmupCommand.php
@@ -20,8 +20,8 @@ class LatteWarmupCommand extends Command
 {
 
 	/**
-	 * @param string[] $dirs
-	 * @param string[] $excludeDirs
+	 * @param list<string> $dirs
+	 * @param list<string> $excludeDirs
 	 */
 	public function __construct(
 		private readonly TemplateFactory $templateFactory,


### PR DESCRIPTION
## Summary
- Fixes default-branch `Phpstan` workflow failure by updating Latte config constructor PHPDoc types from `string[]` to `list<string>`.
- Aligns static types with `Nette\Utils\Finder::from()` and `Finder::exclude()` expectations (`list<string>|string`) in both Latte warmup paths.
- Verified locally with `make qa` and `make tests`.

## Investigation
- Latest failed default-branch run: https://github.com/contributte/console-extra/actions/runs/21818583065
- Failure reason: PHPStan argument type mismatch for `Finder::from()`/`exclude()` in `LatteWarmupCommand` and `LatteTemplatesCacheGenerator`.
- No linked repository issue was found.