### PR TITLE
Docs: migrate Coveralls badge to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/console-extra/actions"><img src="https://badgen.net/github/checks/contributte/console-extra/master?cache=300"></a>
-  <a href="https://coveralls.io/r/contributte/console-extra"><img src="https://badgen.net/coveralls/c/github/contributte/console-extra?cache=300"></a>
+  <a href="https://codecov.io/gh/contributte/console-extra"><img src="https://badgen.net/codecov/c/github/contributte/console-extra"></a>
   <a href="https://packagist.org/packages/contributte/console-extra"><img src="https://badgen.net/packagist/dm/contributte/console-extra"></a>
   <a href="https://packagist.org/packages/contributte/console-extra"><img src="https://badgen.net/packagist/v/contributte/console-extra"></a>
 </p>

--- a/src/Command/Router/RouterDumpCommand.php
+++ b/src/Command/Router/RouterDumpCommand.php
@@ -103,31 +103,31 @@ final class RouterDumpCommand extends Command
 	}
 
 	/**
-	 * @param string[] $defaults
+	 * @param array<string, mixed> $defaults
 	 */
 	protected function analyseDefaults(array $defaults): string
 	{
 		$primary = [];
 
 		if (isset($defaults['presenter'])) {
-			$primary[] = $defaults['presenter'];
+			$primary[] = $this->stringifyDefault($defaults['presenter']);
 			unset($defaults['presenter']);
 		}
 
 		if (isset($defaults['action'])) {
-			$primary[] = $defaults['action'];
+			$primary[] = $this->stringifyDefault($defaults['action']);
 			unset($defaults['action']);
 		}
 
 		if (isset($defaults['id'])) {
-			$primary[] = $defaults['id'];
+			$primary[] = $this->stringifyDefault($defaults['id']);
 			unset($defaults['id']);
 		}
 
 		$secondary = [];
 
 		foreach ($defaults as $key => $value) {
-			$secondary[] = sprintf('%s=>%s', $key, $value);
+			$secondary[] = sprintf('%s=>%s', $key, $this->stringifyDefault($value));
 		}
 
 		if ($secondary !== []) {
@@ -135,6 +135,19 @@ final class RouterDumpCommand extends Command
 		}
 
 		return implode(':', $primary);
+	}
+
+	protected function stringifyDefault(mixed $value): string
+	{
+		if (is_string($value)) {
+			return $value;
+		}
+
+		if (is_scalar($value) || $value === null) {
+			return var_export($value, true);
+		}
+
+		return get_debug_type($value);
 	}
 
 }

--- a/tests/Cases/Command/Router/RouterDumpCommand.phpt
+++ b/tests/Cases/Command/Router/RouterDumpCommand.phpt
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Command\Router;
+
+use Contributte\Console\Extra\Command\Router\RouterDumpCommand;
+use Contributte\Tester\Toolkit;
+use Nette\Application\Routers\RouteList;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+Toolkit::test(function (): void {
+	$router = new RouteList();
+	$router->addRoute('api/<presenter>/<action>', [
+		'presenter' => 'Api:Dashboard',
+		'action' => 'default',
+	]);
+
+	$admin = $router->withModule('Admin');
+	$admin->addRoute('admin/<presenter>/<action>[/<id>]', [
+		'presenter' => 'Dashboard',
+		'action' => 'default',
+		'id' => 1,
+		'lang' => 'cs',
+		'secured' => true,
+		'meta' => ['role' => 'admin'],
+	]);
+
+	$application = new Application();
+	$application->addCommand(new RouterDumpCommand($router));
+
+	$command = $application->find('nette:router:dump');
+	$commandTester = new CommandTester($command);
+	$commandTester->execute([]);
+
+	$display = $commandTester->getDisplay();
+	$analyseDefaults = \Closure::bind(
+		fn (array $defaults): string => $this->analyseDefaults($defaults),
+		$command,
+		RouterDumpCommand::class,
+	);
+
+	Assert::true(str_contains($display, 'api/<presenter>/<action>'));
+	Assert::true(str_contains($display, 'Api:Dashboard:default'));
+	Assert::true(str_contains($display, 'admin/<presenter>/<action>[/<id>]'));
+	Assert::true(str_contains($display, 'Admin'));
+	Assert::true(str_contains($display, 'Dashboard:default:1 [lang=>cs,secured=>1]'));
+	Assert::same('Dashboard:default:1 [lang=>cs,secured=>true,meta=>array]', $analyseDefaults([
+		'presenter' => 'Dashboard',
+		'action' => 'default',
+		'id' => 1,
+		'lang' => 'cs',
+		'secured' => true,
+		'meta' => ['role' => 'admin'],
+	]));
+});


### PR DESCRIPTION
What changed
- switched the README coverage badge from Coveralls to Codecov to match the current Contributte migration pattern
- verified there are no remaining Coveralls references in the tracked project files and that `.github/workflows/coverage.yml` already uses the shared coverage workflow

Why
- this finishes the remaining Coveralls-to-Codecov migration work for `contributte/console-extra`
- keeps the repository aligned with contributte/contributte#72