### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Switch the `coverage` Makefile target from `phpdbg` to `php` so this repository follows the org-wide coverage runner migration.

## Motivation

This repository is part of contributte/contributte#73, which removes `phpdbg` from coverage targets across Contributte packages.

## Changes

- replace `-p phpdbg` with `-p php` in both `coverage` target variants in `Makefile`
- keep the existing coverage output targets for CI (`coverage.xml`) and local runs (`coverage.html`)

## Testing

- [x] Tests pass locally (`make tests`)
- [ ] Coverage target passes locally (`make coverage`)
- [ ] CI passes

`make coverage` currently fails in this environment because PHP CLI has no Xdebug/PCOV extension and coverage is no longer running under PHPDBG.